### PR TITLE
PatchWork AutoFix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
 
   redis:
     image: redis:alpine
+    security_opt:
+      - no-new-privileges: true
+    read_only: true
 
   sqli:
     build:
@@ -22,3 +25,4 @@ services:
       - 8080:8080
     command: |
       wait-for postgres:5432 -- python run.py
+

--- a/sqli/dao/student.py
+++ b/sqli/dao/student.py
@@ -39,9 +39,9 @@ class Student(NamedTuple):
 
     @staticmethod
     async def create(conn: Connection, name: str):
-        q = ("INSERT INTO students (name) "
-             "VALUES ('%(name)s')" % {'name': name})
         async with conn.cursor() as cur:
-            await cur.execute(q)
-
+            await cur.execute(
+                "INSERT INTO students (name) VALUES (%s)",
+                (name,),
+            )
 

--- a/sqli/dao/user.py
+++ b/sqli/dao/user.py
@@ -1,5 +1,6 @@
 from hashlib import md5
 from typing import NamedTuple, Optional
+import hashlib
 
 from aiopg import Connection
 
@@ -38,4 +39,4 @@ class User(NamedTuple):
             return User.from_raw(await cur.fetchone())
 
     def check_password(self, password: str):
-        return self.pwd_hash == md5(password.encode('utf-8')).hexdigest()
+        return self.pwd_hash == hashlib.scrypt(password.encode('utf-8'), salt=b'saltysalt', n=2**14, r=8, p=1).hex()


### PR DESCRIPTION
This pull request from patched fixes 3 issues.

------

<div markdown="1">

* File changed: [docker-compose.yml]({{docker-compose.yml}})<details><summary>[Fix: Set 'read_only: true' and 'no-new-privileges: true' in redis service]({{docker-compose.yml:1:24}})</summary>  - Added 'read_only: true' to the 'redis' service to prevent malicious applications from modifying container files.
  - Added 'no-new-privileges: true' to the 'redis' service to prevent privilege escalation via setuid or setgid binaries.</details>

</div>

<div markdown="1">

* File changed: [sqli/dao/student.py]({{sqli/dao/student.py}})<details><summary>[Fix: Use parameterized query in Student.create]({{sqli/dao/student.py:1:47}})</summary>  The `Student.create` method was vulnerable to SQL injection because it used string concatenation to build the SQL query. This commit fixes the vulnerability by using a parameterized query instead.</details>

</div>

<div markdown="1">

* File changed: [sqli/dao/user.py]({{sqli/dao/user.py}})<details><summary>[Upgrade password hashing algorithm from MD5 to scrypt]({{sqli/dao/user.py:1:41}})</summary>  The `check_password` method has been updated to use the `scrypt` algorithm for password hashing instead of `md5`. Scrypt is considered more secure than MD5 and is more resistant to brute-force attacks.</details>

</div>