### PR TITLE
PatchWork AutoFix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
 
   redis:
     image: redis:alpine
+    security_opt:
+      - "no-new-privileges:true"
+    read_only: true
 
   sqli:
     build:

--- a/sqli/dao/student.py
+++ b/sqli/dao/student.py
@@ -39,9 +39,6 @@ class Student(NamedTuple):
 
     @staticmethod
     async def create(conn: Connection, name: str):
-        q = ("INSERT INTO students (name) "
-             "VALUES ('%(name)s')" % {'name': name})
+        q = "INSERT INTO students (name) VALUES (%s)"
         async with conn.cursor() as cur:
-            await cur.execute(q)
-
-
+            await cur.execute(q, (name,))

--- a/sqli/dao/user.py
+++ b/sqli/dao/user.py
@@ -1,4 +1,4 @@
-from hashlib import md5
+from hashlib import scrypt
 from typing import NamedTuple, Optional
 
 from aiopg import Connection
@@ -10,7 +10,7 @@ class User(NamedTuple):
     middle_name: Optional[str]
     last_name: str
     username: str
-    pwd_hash: str
+    pwd_hash: bytes
     is_admin: bool
 
     @classmethod
@@ -38,4 +38,4 @@ class User(NamedTuple):
             return User.from_raw(await cur.fetchone())
 
     def check_password(self, password: str):
-        return self.pwd_hash == md5(password.encode('utf-8')).hexdigest()
+        return self.pwd_hash == scrypt(password.encode('utf-8'), salt=b'salt', n=16384, r=8, p=1)


### PR DESCRIPTION
This pull request from patched fixes 3 issues.

------

<div markdown="1">

* File changed: [docker-compose.yml]({{docker-compose.yml}})<details><summary>[Prevent privilege escalation and protect root filesystem in Redis service]({{docker-compose.yml:1:24}})</summary>  Added 'security_opt' with 'no-new-privileges:true' and 'read_only: true' to the Redis service to prevent privilege escalation and protect the root filesystem.</details>

</div>

<div markdown="1">

* File changed: [sqli/dao/student.py]({{sqli/dao/student.py}})<details><summary>[Fix SQL Injection vulnerability by using parameterized queries]({{sqli/dao/student.py:1:47}})</summary>  Replaced string concatenation with parameterized queries in the create method to prevent SQL Injection vulnerability.</details>

</div>

<div markdown="1">

* File changed: [sqli/dao/user.py]({{sqli/dao/user.py}})<details><summary>[Fix vulnerability by replacing usage of MD5 with hashlib.scrypt]({{sqli/dao/user.py:1:41}})</summary>  Replaced the usage of MD5 hash function with hashlib.scrypt in the check_password method for secure password hashing.</details>

</div>